### PR TITLE
Fix redirects to work with subdirectory installations of pico

### DIFF
--- a/pico_private.php
+++ b/pico_private.php
@@ -74,12 +74,12 @@ class Pico_Private {
   }
 
   private function redirect_home() {
-    header('Location: /'); 
+    header('Location: ./'); 
     exit;
   }
 
   private function redirect_login() {
-    header('Location: /login'); 
+    header('Location: ./login'); 
     exit;
   }
 


### PR DESCRIPTION
This should fix a little problem I had. When pico is not installed in the base directory of the server "/", the redirect functions redirect_home() and redirect_login() break the site.

(the solution seems to simple to be right, needs testing i guess)
Now part of pull#5
